### PR TITLE
(#8) Consumption endpoint

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/repository/OctopusRestApiRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/repository/OctopusRestApiRepository.kt
@@ -7,29 +7,34 @@
 
 package com.rwmobi.roctopus.data.repository
 
+import com.rwmobi.roctopus.data.repository.mapper.toConsumption
 import com.rwmobi.roctopus.data.repository.mapper.toProduct
 import com.rwmobi.roctopus.data.repository.mapper.toRate
+import com.rwmobi.roctopus.data.source.network.ElectricityMeterPointsEndpoint
 import com.rwmobi.roctopus.data.source.network.ProductsEndpoint
+import com.rwmobi.roctopus.data.source.network.model.ConsumptionGrouping
+import com.rwmobi.roctopus.data.source.network.model.ConsumptionOrdering
 import com.rwmobi.roctopus.domain.exceptions.except
+import com.rwmobi.roctopus.domain.model.Consumption
 import com.rwmobi.roctopus.domain.model.Product
 import com.rwmobi.roctopus.domain.model.Rate
 import com.rwmobi.roctopus.domain.repository.OctopusRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.cancellation.CancellationException
 
 class OctopusRestApiRepository(
     private val productsEndpoint: ProductsEndpoint,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val electricityMeterPointsEndpoint: ElectricityMeterPointsEndpoint,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : OctopusRepository {
 
     override suspend fun getProducts(): Result<List<Product>> {
         return withContext(dispatcher) {
             runCatching {
                 val apiResponse = productsEndpoint.getProducts()
-                apiResponse?.results?.toProduct() ?: emptyList()
+                apiResponse?.results?.map { it.toProduct() } ?: emptyList()
             }.except<CancellationException, _>()
         }
     }
@@ -44,7 +49,7 @@ class OctopusRestApiRepository(
                     productCode = productCode,
                     tariffCode = tariffCode,
                 )
-                apiResponse?.results?.toRate() ?: emptyList()
+                apiResponse?.results?.map { it.toRate() } ?: emptyList()
             }.except<CancellationException, _>()
         }
     }
@@ -59,7 +64,7 @@ class OctopusRestApiRepository(
                     productCode = productCode,
                     tariffCode = tariffCode,
                 )
-                apiResponse?.results?.toRate() ?: emptyList()
+                apiResponse?.results?.map { it.toRate() } ?: emptyList()
             }.except<CancellationException, _>()
         }
     }
@@ -74,7 +79,7 @@ class OctopusRestApiRepository(
                     productCode = productCode,
                     tariffCode = tariffCode,
                 )
-                apiResponse?.results?.toRate() ?: emptyList()
+                apiResponse?.results?.map { it.toRate() } ?: emptyList()
             }.except<CancellationException, _>()
         }
     }
@@ -89,7 +94,26 @@ class OctopusRestApiRepository(
                     productCode = productCode,
                     tariffCode = tariffCode,
                 )
-                apiResponse?.results?.toRate() ?: emptyList()
+                apiResponse?.results?.map { it.toRate() } ?: emptyList()
+            }.except<CancellationException, _>()
+        }
+    }
+
+    override suspend fun getConsumption(
+        apiKey: String,
+        mpan: String,
+        meterSerialNumber: String,
+    ): Result<List<Consumption>> {
+        return withContext(dispatcher) {
+            runCatching {
+                val apiResponse = electricityMeterPointsEndpoint.getConsumption(
+                    apiKey = apiKey,
+                    mpan = mpan,
+                    meterSerialNumber = meterSerialNumber,
+                    orderBy = ConsumptionOrdering.PERIOD,
+                    groupBy = ConsumptionGrouping.HALF_HOURLY,
+                )
+                apiResponse?.results?.map { it.toConsumption() } ?: emptyList()
             }.except<CancellationException, _>()
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/repository/mapper/ConsumptionMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/repository/mapper/ConsumptionMapper.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.roctopus.data.repository.mapper
+
+import com.rwmobi.roctopus.data.source.network.dto.ConsumptionDto
+import com.rwmobi.roctopus.domain.model.Consumption
+
+fun ConsumptionDto.toConsumption() = Consumption(
+    consumption = consumption,
+    intervalStart = intervalStart,
+    intervalEnd = intervalEnd,
+)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/repository/mapper/ProductMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/repository/mapper/ProductMapper.kt
@@ -11,24 +11,20 @@ import com.rwmobi.roctopus.data.source.network.dto.ProductDetailsDto
 import com.rwmobi.roctopus.domain.model.Product
 import com.rwmobi.roctopus.domain.model.ProductDirection
 
-fun ProductDetailsDto.toProduct(): Product {
-    return Product(
-        code = code,
-        direction = ProductDirection.fromValue(direction),
-        fullName = fullName,
-        displayName = displayName,
-        description = description,
-        isVariable = isVariable,
-        isGreen = isGreen,
-        isTracker = isTracker,
-        isPrepay = isPrepay,
-        isBusiness = isBusiness,
-        isRestricted = isRestricted,
-        term = term,
-        availableFrom = availableFrom,
-        availableTo = availableTo,
-        brand = brand,
-    )
-}
-
-fun List<ProductDetailsDto>.toProduct(): List<Product> = map { it.toProduct() }
+fun ProductDetailsDto.toProduct() = Product(
+    code = code,
+    direction = ProductDirection.fromValue(direction),
+    fullName = fullName,
+    displayName = displayName,
+    description = description,
+    isVariable = isVariable,
+    isGreen = isGreen,
+    isTracker = isTracker,
+    isPrepay = isPrepay,
+    isBusiness = isBusiness,
+    isRestricted = isRestricted,
+    term = term,
+    availableFrom = availableFrom,
+    availableTo = availableTo,
+    brand = brand,
+)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/repository/mapper/RateMapper.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/repository/mapper/RateMapper.kt
@@ -11,14 +11,10 @@ import com.rwmobi.roctopus.data.source.network.dto.RateDto
 import com.rwmobi.roctopus.domain.model.PaymentMethod
 import com.rwmobi.roctopus.domain.model.Rate
 
-fun RateDto.toRate(): Rate {
-    return Rate(
-        vatExclusivePrice = vatExclusivePrice,
-        vatInclusivePrice = vatInclusivePrice,
-        validFrom = validFrom,
-        validTo = validTo,
-        paymentMethod = PaymentMethod.fromValue(paymentMethod),
-    )
-}
-
-fun List<RateDto>.toRate(): List<Rate> = map { it.toRate() }
+fun RateDto.toRate() = Rate(
+    vatExclusivePrice = vatExclusivePrice,
+    vatInclusivePrice = vatInclusivePrice,
+    validFrom = validFrom,
+    validTo = validTo,
+    paymentMethod = PaymentMethod.fromValue(paymentMethod),
+)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/source/network/ElectricityMeterPointsEndpoint.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/source/network/ElectricityMeterPointsEndpoint.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.roctopus.data.source.network
+
+import com.rwmobi.roctopus.data.source.network.dto.ConsumptionApiResponse
+import com.rwmobi.roctopus.data.source.network.model.ConsumptionGrouping
+import com.rwmobi.roctopus.data.source.network.model.ConsumptionOrdering
+import com.rwmobi.roctopus.domain.extensions.formatInstantWithoutSeconds
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonPrimitive
+
+class ElectricityMeterPointsEndpoint(
+    baseUrl: String,
+    private val httpClient: HttpClient,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    private val endpointUrl = "$baseUrl/v1/electricity-meter-points/"
+
+    /**
+     * For billing, consumption needs to call roundToNearestEvenHundredth(). See comments there.
+     */
+    suspend fun getConsumption(
+        apiKey: String,
+        mpan: String,
+        meterSerialNumber: String,
+        pageSize: Int? = null,
+        periodFrom: Instant? = null,
+        periodTo: Instant? = null,
+        orderBy: ConsumptionOrdering = ConsumptionOrdering.LATEST_FIRST,
+        groupBy: ConsumptionGrouping = ConsumptionGrouping.HALF_HOURLY,
+    ): ConsumptionApiResponse? {
+        return withContext(dispatcher) {
+            httpClient.get("$endpointUrl/$mpan/meters/$meterSerialNumber/consumption") {
+                header("Authorization", "Basic ${encodeApiKey(apiKey)}")
+                parameter("page_size", pageSize)
+                parameter("period_from", periodFrom?.formatInstantWithoutSeconds())
+                parameter("period_to", periodTo?.formatInstantWithoutSeconds())
+                parameter("order_by", orderBy.apiValue)
+                parameter("group_by", groupBy.apiValue)
+            }.body()
+        }
+    }
+
+    private fun encodeApiKey(apiKey: String): String {
+        // This uses JSON encoding to indirectly perform Base64 encoding
+        val jsonElement = Json.encodeToJsonElement(JsonPrimitive(apiKey))
+        return jsonElement.jsonPrimitive.content
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/source/network/ElectricityMeterPointsEndpoint.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/source/network/ElectricityMeterPointsEndpoint.kt
@@ -16,15 +16,14 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
+import io.ktor.utils.io.core.toByteArray
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
 import kotlinx.datetime.Instant
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonPrimitive
-import kotlinx.serialization.json.encodeToJsonElement
-import kotlinx.serialization.json.jsonPrimitive
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
 
 class ElectricityMeterPointsEndpoint(
     baseUrl: String,
@@ -58,9 +57,8 @@ class ElectricityMeterPointsEndpoint(
         }
     }
 
+    @OptIn(ExperimentalEncodingApi::class)
     private fun encodeApiKey(apiKey: String): String {
-        // This uses JSON encoding to indirectly perform Base64 encoding
-        val jsonElement = Json.encodeToJsonElement(JsonPrimitive(apiKey))
-        return jsonElement.jsonPrimitive.content
+        return Base64.encode("$apiKey:".toByteArray())
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/source/network/dto/ConsumptionApiResponse.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/source/network/dto/ConsumptionApiResponse.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.roctopus.data.source.network.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ConsumptionApiResponse(
+    val count: Int,
+    val next: String?,
+    val previous: String?,
+    val results: List<ConsumptionDto>,
+)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/source/network/dto/ConsumptionDto.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/source/network/dto/ConsumptionDto.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.roctopus.data.source.network.dto
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ConsumptionDto(
+    @SerialName("consumption") val consumption: Double,
+    @SerialName("interval_start") val intervalStart: Instant,
+    @SerialName("interval_end") val intervalEnd: Instant,
+)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/source/network/model/ConsumptionGrouping.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/source/network/model/ConsumptionGrouping.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.roctopus.data.source.network.model
+
+enum class ConsumptionGrouping(val apiValue: String?) {
+    // This aggregates half hours into days based on the local time, not the UTC time, so there will be one fewer hour included on the daylight savings in the spring.
+    HALF_HOURLY(apiValue = null),
+    DAY(apiValue = "day"),
+    WEEK(apiValue = "week"),
+    MONTH(apiValue = "month"),
+    QUARTER(apiValue = "quarter"),
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/source/network/model/ConsumptionOrdering.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/data/source/network/model/ConsumptionOrdering.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.roctopus.data.source.network.model
+
+enum class ConsumptionOrdering(val apiValue: String?) {
+    PERIOD(apiValue = "period"),
+    LATEST_FIRST(apiValue = null),
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/di/KtorModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/di/KtorModule.kt
@@ -42,7 +42,9 @@ val ktorModule = module {
             baseUrl = BASE_URL,
             httpClient = get(),
         )
+    }
 
+    factory {
         ElectricityMeterPointsEndpoint(
             baseUrl = BASE_URL,
             httpClient = get(),

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/di/KtorModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/di/KtorModule.kt
@@ -7,6 +7,7 @@
 
 package com.rwmobi.roctopus.di
 
+import com.rwmobi.roctopus.data.source.network.ElectricityMeterPointsEndpoint
 import com.rwmobi.roctopus.data.source.network.ProductsEndpoint
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
@@ -36,9 +37,13 @@ val ktorModule = module {
         }
     }
 
-    // Provide ProductsEndpoint
     factory {
         ProductsEndpoint(
+            baseUrl = BASE_URL,
+            httpClient = get(),
+        )
+
+        ElectricityMeterPointsEndpoint(
             baseUrl = BASE_URL,
             httpClient = get(),
         )

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/di/RepositoryModule.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/di/RepositoryModule.kt
@@ -15,6 +15,7 @@ val repositoryModule = module {
     single<OctopusRepository> {
         OctopusRestApiRepository(
             productsEndpoint = get(),
+            electricityMeterPointsEndpoint = get(),
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/domain/extensions/DoubleExtensions.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/domain/extensions/DoubleExtensions.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.roctopus.domain.extensions
+
+import kotlin.math.roundToLong
+
+/**
+ * Electricity consumption data is returned to the nearest 0.001kwh.
+ * For billing, consumption is rounded to the nearest 0.01kwh before multiplying by the price.
+ * The rounding method used is rounding half to even, where numbers ending in 5 are rounded up or down, towards the nearest even hundredth decimal place.
+ * As a result, 0.015 would be rounded up to 0.02, while 0.025 is rounded down to 0.02.
+ */
+fun Double.roundToNearestEvenHundredth(): Double {
+    val scaled = this * 100
+    val rounded = scaled.roundToLong()
+    return rounded / 100.0
+}

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/domain/model/Consumption.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/domain/model/Consumption.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.roctopus.domain.model
+
+import kotlinx.datetime.Instant
+
+data class Consumption(
+    val consumption: Double,
+    val intervalStart: Instant,
+    val intervalEnd: Instant,
+)

--- a/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/domain/repository/OctopusRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/rwmobi/roctopus/domain/repository/OctopusRepository.kt
@@ -7,6 +7,7 @@
 
 package com.rwmobi.roctopus.domain.repository
 
+import com.rwmobi.roctopus.domain.model.Consumption
 import com.rwmobi.roctopus.domain.model.Product
 import com.rwmobi.roctopus.domain.model.Rate
 
@@ -16,4 +17,5 @@ interface OctopusRepository {
     suspend fun getStandingCharges(productCode: String, tariffCode: String): Result<List<Rate>>
     suspend fun getDayUnitRates(productCode: String, tariffCode: String): Result<List<Rate>>
     suspend fun getNightUnitRates(productCode: String, tariffCode: String): Result<List<Rate>>
+    suspend fun getConsumption(apiKey: String, mpan: String, meterSerialNumber: String): Result<List<Consumption>>
 }

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/roctopus/data/source/network/ElectricityMeterPointsEndpointTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/roctopus/data/source/network/ElectricityMeterPointsEndpointTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.roctopus.data.source.network
+
+import com.rwmobi.roctopus.data.source.network.samples.GetConsumptionSampleData
+import io.kotest.assertions.throwables.shouldThrowExactly
+import io.kotest.matchers.shouldBe
+import io.ktor.client.HttpClient
+import io.ktor.client.call.NoTransformationFoundException
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.utils.io.ByteReadChannel
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+
+class ElectricityMeterPointsEndpointTest {
+    private val fakeBaseUrl = "https://some.fakeurl.com"
+    private val fakeApiKey = "sk_live_xXxX1xx1xx1xx1XXxX1Xxx1x"
+    private val fakeMpan = "1100000111111"
+    private val fakeMeterSerialNumber = "11L1111111"
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private fun setupEngine(status: HttpStatusCode, contentType: String, payload: String): HttpClient {
+        val mockEngine = MockEngine { _ ->
+            respond(
+                content = ByteReadChannel(payload),
+                status = status,
+                headers = headersOf(HttpHeaders.ContentType, contentType),
+            )
+        }
+
+        return HttpClient(engine = mockEngine) {
+            install(ContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                        prettyPrint = true
+                        isLenient = true
+                        allowTrailingComma = true
+                    },
+                )
+            }
+        }
+    }
+
+    // 🗂 getConsumption
+    @Test
+    fun getConsumption_ShouldReturnExpectedDto_WhenHttpStatusIsOK() = runTest {
+        val electricityMeterPointsEndpoint = ElectricityMeterPointsEndpoint(
+            baseUrl = fakeBaseUrl,
+            httpClient = setupEngine(
+                status = HttpStatusCode.OK,
+                contentType = "application/json",
+                payload = GetConsumptionSampleData.json,
+            ),
+        )
+
+        val result = electricityMeterPointsEndpoint.getConsumption(
+            apiKey = fakeApiKey,
+            mpan = fakeMpan,
+            meterSerialNumber = fakeMeterSerialNumber,
+        )
+        result shouldBe GetConsumptionSampleData.dto
+    }
+
+    @Test
+    fun getConsumption_ShouldThrowNoTransformationFoundException_WhenHttpStatusIsInternalServerError() = runTest {
+        val electricityMeterPointsEndpoint = ElectricityMeterPointsEndpoint(
+            baseUrl = fakeBaseUrl,
+            httpClient = setupEngine(
+                status = HttpStatusCode.InternalServerError,
+                contentType = "text/html",
+                payload = "Internal Server Error",
+            ),
+        )
+
+        shouldThrowExactly<NoTransformationFoundException> {
+            electricityMeterPointsEndpoint.getConsumption(
+                apiKey = fakeApiKey,
+                mpan = fakeMpan,
+                meterSerialNumber = fakeMeterSerialNumber,
+            )
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/rwmobi/roctopus/data/source/network/samples/GetConsumptionSampleData.kt
+++ b/composeApp/src/commonTest/kotlin/com/rwmobi/roctopus/data/source/network/samples/GetConsumptionSampleData.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024. Ryan Wong
+ * https://github.com/ryanw-mobile
+ * Sponsored by RW MobiMedia UK Limited
+ *
+ */
+
+package com.rwmobi.roctopus.data.source.network.samples
+
+import com.rwmobi.roctopus.data.source.network.dto.ConsumptionApiResponse
+import com.rwmobi.roctopus.data.source.network.dto.ConsumptionDto
+import kotlinx.datetime.Instant
+
+object GetConsumptionSampleData {
+    val json = """{
+  "count": 768,
+  "next": "https://api.octopus.energy/v1/electricity-meter-points/1100000111111/meters/11L1111111/consumption/?page=2",
+  "previous": null,
+  "results": [
+    {
+      "consumption": 0.113,
+      "interval_start": "2024-05-07T00:30:00+01:00",
+      "interval_end": "2024-05-07T01:00:00+01:00"
+    },
+    {
+      "consumption": 0.58,
+      "interval_start": "2024-05-07T00:00:00+01:00",
+      "interval_end": "2024-05-07T00:30:00+01:00"
+    },
+    {
+      "consumption": 0.201,
+      "interval_start": "2024-05-06T23:30:00+01:00",
+      "interval_end": "2024-05-07T00:00:00+01:00"
+    },
+    {
+      "consumption": 0.451,
+      "interval_start": "2024-05-06T23:00:00+01:00",
+      "interval_end": "2024-05-06T23:30:00+01:00"
+    },
+    {
+      "consumption": 0.512,
+      "interval_start": "2024-05-06T22:30:00+01:00",
+      "interval_end": "2024-05-06T23:00:00+01:00"
+    }
+  ]
+}
+    """.trimIndent()
+
+    val dto = ConsumptionApiResponse(
+        count = 768,
+        next = "https://api.octopus.energy/v1/electricity-meter-points/1100000111111/meters/11L1111111/consumption/?page=2",
+        previous = null,
+        results = listOf(
+            ConsumptionDto(
+                consumption = 0.113,
+                intervalStart = Instant.parse("2024-05-06T23:30:00Z"),
+                intervalEnd = Instant.parse("2024-05-07T00:00:00Z"),
+            ),
+            ConsumptionDto(
+                consumption = 0.58,
+                intervalStart = Instant.parse("2024-05-06T23:00:00Z"),
+                intervalEnd = Instant.parse("2024-05-06T23:30:00Z"),
+            ),
+            ConsumptionDto(
+                consumption = 0.201,
+                intervalStart = Instant.parse("2024-05-06T22:30:00Z"),
+                intervalEnd = Instant.parse("2024-05-06T23:00:00Z"),
+            ),
+            ConsumptionDto(
+                consumption = 0.451,
+                intervalStart = Instant.parse("2024-05-06T22:00:00Z"),
+                intervalEnd = Instant.parse("2024-05-06T22:30:00Z"),
+            ),
+            ConsumptionDto(
+                consumption = 0.512,
+                intervalStart = Instant.parse("2024-05-06T21:30:00Z"),
+                intervalEnd = Instant.parse("2024-05-06T22:00:00Z"),
+            ),
+        ),
+    )
+}


### PR DESCRIPTION
ElectricityMeterPointsEndpoint data source with unit test
basic repository linkup (no unit test yet)
basic domain model and extension function for rounding usage for billing

requires API, meter and MPAN which later should be provided by viewmodel from another user preference repository.
